### PR TITLE
adapt to nvim_011 lsp

### DIFF
--- a/nvim/.config/nvim/lua/toga/plugins/lsp/lspconfig.lua
+++ b/nvim/.config/nvim/lua/toga/plugins/lsp/lspconfig.lua
@@ -7,8 +7,7 @@ return {
         { "folke/neodev.nvim", opts = {} },
     },
     config = function()
-        -- import lspconfig plugin
-        local lspconfig = require("lspconfig")
+        local lspconfig = vim.lsp.config
 
         -- import mason_lspconfig plugin
         local mason_lspconfig = require("mason-lspconfig")

--- a/nvim/.config/nvim/lua/toga/plugins/lsp/mason.lua
+++ b/nvim/.config/nvim/lua/toga/plugins/lsp/mason.lua
@@ -55,7 +55,8 @@ return {
                 "eslint_d",
             },
         })
-        require("lspconfig").clangd.setup({
+
+        vim.lsp.config("clangd", {
             cmd = {
                 "clangd",
                 "--background-index",


### PR DESCRIPTION
`vim.lsp.config` deprecates `require('lsponfig')` in nvim 0.11